### PR TITLE
Fixes #1

### DIFF
--- a/azuredevops/azuredevops-accessors.go
+++ b/azuredevops/azuredevops-accessors.go
@@ -7,10 +7,6 @@
 
 package azuredevops
 
-import (
-	"time"
-)
-
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (a *AgentPoolQueue) GetID() int {
 	if a == nil || a.ID == nil {
@@ -891,20 +887,20 @@ func (c *Comment) GetIsDeleted() bool {
 	return *c.IsDeleted
 }
 
-// GetLastContentUpdatedDate returns the LastContentUpdatedDate field if it's non-nil, zero value otherwise.
-func (c *Comment) GetLastContentUpdatedDate() time.Time {
-	if c == nil || c.LastContentUpdatedDate == nil {
-		return time.Time{}
+// GetLastContentUpdatedDate returns the LastContentUpdatedDate field.
+func (c *Comment) GetLastContentUpdatedDate() *Time {
+	if c == nil {
+		return nil
 	}
-	return *c.LastContentUpdatedDate
+	return c.LastContentUpdatedDate
 }
 
-// GetLastUpdatedDate returns the LastUpdatedDate field if it's non-nil, zero value otherwise.
-func (c *Comment) GetLastUpdatedDate() time.Time {
-	if c == nil || c.LastUpdatedDate == nil {
-		return time.Time{}
+// GetLastUpdatedDate returns the LastUpdatedDate field.
+func (c *Comment) GetLastUpdatedDate() *Time {
+	if c == nil {
+		return nil
 	}
-	return *c.LastUpdatedDate
+	return c.LastUpdatedDate
 }
 
 // GetLinks returns the Links field if it's non-nil, zero value otherwise.
@@ -923,12 +919,12 @@ func (c *Comment) GetParentCommentID() int {
 	return *c.ParentCommentID
 }
 
-// GetPublishedDate returns the PublishedDate field if it's non-nil, zero value otherwise.
-func (c *Comment) GetPublishedDate() time.Time {
-	if c == nil || c.PublishedDate == nil {
-		return time.Time{}
+// GetPublishedDate returns the PublishedDate field.
+func (c *Comment) GetPublishedDate() *Time {
+	if c == nil {
+		return nil
 	}
-	return *c.PublishedDate
+	return c.PublishedDate
 }
 
 // GetLine returns the Line field if it's non-nil, zero value otherwise.
@@ -1451,12 +1447,12 @@ func (g *GitPullRequest) GetClosedBy() *IdentityRef {
 	return g.ClosedBy
 }
 
-// GetClosedDate returns the ClosedDate field if it's non-nil, zero value otherwise.
-func (g *GitPullRequest) GetClosedDate() time.Time {
-	if g == nil || g.ClosedDate == nil {
-		return time.Time{}
+// GetClosedDate returns the ClosedDate field.
+func (g *GitPullRequest) GetClosedDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.ClosedDate
+	return g.ClosedDate
 }
 
 // GetCodeReviewID returns the CodeReviewID field if it's non-nil, zero value otherwise.
@@ -1475,12 +1471,12 @@ func (g *GitPullRequest) GetCompletionOptions() *GitPullRequestCompletionOptions
 	return g.CompletionOptions
 }
 
-// GetCompletionQueueTime returns the CompletionQueueTime field if it's non-nil, zero value otherwise.
-func (g *GitPullRequest) GetCompletionQueueTime() time.Time {
-	if g == nil || g.CompletionQueueTime == nil {
-		return time.Time{}
+// GetCompletionQueueTime returns the CompletionQueueTime field.
+func (g *GitPullRequest) GetCompletionQueueTime() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.CompletionQueueTime
+	return g.CompletionQueueTime
 }
 
 // GetCreatedBy returns the CreatedBy field.
@@ -1491,12 +1487,12 @@ func (g *GitPullRequest) GetCreatedBy() *IdentityRef {
 	return g.CreatedBy
 }
 
-// GetCreationDate returns the CreationDate field if it's non-nil, zero value otherwise.
-func (g *GitPullRequest) GetCreationDate() time.Time {
-	if g == nil || g.CreationDate == nil {
-		return time.Time{}
+// GetCreationDate returns the CreationDate field.
+func (g *GitPullRequest) GetCreationDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.CreationDate
+	return g.CreationDate
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -1683,12 +1679,12 @@ func (g *GitPullRequestCommentThread) GetIsDeleted() bool {
 	return *g.IsDeleted
 }
 
-// GetLastUpdatedDate returns the LastUpdatedDate field if it's non-nil, zero value otherwise.
-func (g *GitPullRequestCommentThread) GetLastUpdatedDate() time.Time {
-	if g == nil || g.LastUpdatedDate == nil {
-		return time.Time{}
+// GetLastUpdatedDate returns the LastUpdatedDate field.
+func (g *GitPullRequestCommentThread) GetLastUpdatedDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.LastUpdatedDate
+	return g.LastUpdatedDate
 }
 
 // GetLinks returns the Links field if it's non-nil, zero value otherwise.
@@ -1699,12 +1695,12 @@ func (g *GitPullRequestCommentThread) GetLinks() map[string]Link {
 	return *g.Links
 }
 
-// GetPublishedDate returns the PublishedDate field if it's non-nil, zero value otherwise.
-func (g *GitPullRequestCommentThread) GetPublishedDate() time.Time {
-	if g == nil || g.PublishedDate == nil {
-		return time.Time{}
+// GetPublishedDate returns the PublishedDate field.
+func (g *GitPullRequestCommentThread) GetPublishedDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.PublishedDate
+	return g.PublishedDate
 }
 
 // GetPullRequestThreadContext returns the PullRequestThreadContext field.
@@ -1843,12 +1839,12 @@ func (g *GitPullRequestMergeOptions) GetDisableRenames() bool {
 	return *g.DisableRenames
 }
 
-// GetProperties returns the Properties field if it's non-nil, zero value otherwise.
-func (g *GitPullRequestStatus) GetProperties() time.Time {
-	if g == nil || g.Properties == nil {
-		return time.Time{}
+// GetProperties returns the Properties field.
+func (g *GitPullRequestStatus) GetProperties() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.Properties
+	return g.Properties
 }
 
 // GetComment returns the Comment field.
@@ -1867,12 +1863,12 @@ func (g *GitPullRequestWithComment) GetPullRequest() *GitPullRequest {
 	return g.PullRequest
 }
 
-// GetDate returns the Date field if it's non-nil, zero value otherwise.
-func (g *GitPush) GetDate() time.Time {
-	if g == nil || g.Date == nil {
-		return time.Time{}
+// GetDate returns the Date field.
+func (g *GitPush) GetDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.Date
+	return g.Date
 }
 
 // GetLinks returns the Links field if it's non-nil, zero value otherwise.
@@ -2211,12 +2207,12 @@ func (g *GitStatus) GetCreatedBy() *IdentityRef {
 	return g.CreatedBy
 }
 
-// GetCreationDate returns the CreationDate field if it's non-nil, zero value otherwise.
-func (g *GitStatus) GetCreationDate() time.Time {
-	if g == nil || g.CreationDate == nil {
-		return time.Time{}
+// GetCreationDate returns the CreationDate field.
+func (g *GitStatus) GetCreationDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.CreationDate
+	return g.CreationDate
 }
 
 // GetDescription returns the Description field if it's non-nil, zero value otherwise.
@@ -2259,12 +2255,12 @@ func (g *GitStatus) GetTargetURL() string {
 	return *g.TargetURL
 }
 
-// GetUpdatedDate returns the UpdatedDate field if it's non-nil, zero value otherwise.
-func (g *GitStatus) GetUpdatedDate() time.Time {
-	if g == nil || g.UpdatedDate == nil {
-		return time.Time{}
+// GetUpdatedDate returns the UpdatedDate field.
+func (g *GitStatus) GetUpdatedDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.UpdatedDate
+	return g.UpdatedDate
 }
 
 // GetGenre returns the Genre field if it's non-nil, zero value otherwise.
@@ -2299,12 +2295,12 @@ func (g *GitTemplate) GetType() string {
 	return *g.Type
 }
 
-// GetDate returns the Date field if it's non-nil, zero value otherwise.
-func (g *GitUserDate) GetDate() time.Time {
-	if g == nil || g.Date == nil {
-		return time.Time{}
+// GetDate returns the Date field.
+func (g *GitUserDate) GetDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.Date
+	return g.Date
 }
 
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
@@ -2507,12 +2503,12 @@ func (g *GraphUser) GetIsDeletedInOrigin() bool {
 	return *g.IsDeletedInOrigin
 }
 
-// GetMetadataUpdateDate returns the MetadataUpdateDate field if it's non-nil, zero value otherwise.
-func (g *GraphUser) GetMetadataUpdateDate() time.Time {
-	if g == nil || g.MetadataUpdateDate == nil {
-		return time.Time{}
+// GetMetadataUpdateDate returns the MetadataUpdateDate field.
+func (g *GraphUser) GetMetadataUpdateDate() *Time {
+	if g == nil {
+		return nil
 	}
-	return *g.MetadataUpdateDate
+	return g.MetadataUpdateDate
 }
 
 // GetMetaType returns the MetaType field if it's non-nil, zero value otherwise.
@@ -2803,12 +2799,12 @@ func (p *Project) GetID() string {
 	return *p.ID
 }
 
-// GetLastUpdateTime returns the LastUpdateTime field if it's non-nil, zero value otherwise.
-func (p *Project) GetLastUpdateTime() time.Time {
-	if p == nil || p.LastUpdateTime == nil {
-		return time.Time{}
+// GetLastUpdateTime returns the LastUpdateTime field.
+func (p *Project) GetLastUpdateTime() *Time {
+	if p == nil {
+		return nil
 	}
-	return *p.LastUpdateTime
+	return p.LastUpdateTime
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.
@@ -3027,12 +3023,12 @@ func (t *TeamProjectReference) GetID() string {
 	return *t.ID
 }
 
-// GetLastUpdateTime returns the LastUpdateTime field if it's non-nil, zero value otherwise.
-func (t *TeamProjectReference) GetLastUpdateTime() time.Time {
-	if t == nil || t.LastUpdateTime == nil {
-		return time.Time{}
+// GetLastUpdateTime returns the LastUpdateTime field.
+func (t *TeamProjectReference) GetLastUpdateTime() *Time {
+	if t == nil {
+		return nil
 	}
-	return *t.LastUpdateTime
+	return t.LastUpdateTime
 }
 
 // GetName returns the Name field if it's non-nil, zero value otherwise.
@@ -3347,12 +3343,12 @@ func (w *WorkItemComment) GetCreatedBy() *IdentityRef {
 	return w.CreatedBy
 }
 
-// GetCreatedDate returns the CreatedDate field if it's non-nil, zero value otherwise.
-func (w *WorkItemComment) GetCreatedDate() time.Time {
-	if w == nil || w.CreatedDate == nil {
-		return time.Time{}
+// GetCreatedDate returns the CreatedDate field.
+func (w *WorkItemComment) GetCreatedDate() *Time {
+	if w == nil {
+		return nil
 	}
-	return *w.CreatedDate
+	return w.CreatedDate
 }
 
 // GetID returns the ID field if it's non-nil, zero value otherwise.
@@ -3371,12 +3367,12 @@ func (w *WorkItemComment) GetModifiedBy() *IdentityRef {
 	return w.ModifiedBy
 }
 
-// GetModifiedDate returns the ModifiedDate field if it's non-nil, zero value otherwise.
-func (w *WorkItemComment) GetModifiedDate() time.Time {
-	if w == nil || w.ModifiedDate == nil {
-		return time.Time{}
+// GetModifiedDate returns the ModifiedDate field.
+func (w *WorkItemComment) GetModifiedDate() *Time {
+	if w == nil {
+		return nil
 	}
-	return *w.ModifiedDate
+	return w.ModifiedDate
 }
 
 // GetText returns the Text field if it's non-nil, zero value otherwise.
@@ -3555,12 +3551,12 @@ func (w *WorkItemUpdate) GetRevisedBy() *IdentityRef {
 	return w.RevisedBy
 }
 
-// GetRevisedDate returns the RevisedDate field if it's non-nil, zero value otherwise.
-func (w *WorkItemUpdate) GetRevisedDate() time.Time {
-	if w == nil || w.RevisedDate == nil {
-		return time.Time{}
+// GetRevisedDate returns the RevisedDate field.
+func (w *WorkItemUpdate) GetRevisedDate() *Time {
+	if w == nil {
+		return nil
 	}
-	return *w.RevisedDate
+	return w.RevisedDate
 }
 
 // GetURL returns the URL field if it's non-nil, zero value otherwise.

--- a/azuredevops/events.go
+++ b/azuredevops/events.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 )
 
 // Message represents an Azure Devops webhook message property
@@ -35,7 +34,7 @@ type Event struct {
 	RawPayload         json.RawMessage    `json:"resource,omitempty"`
 	ResourceVersion    string             `json:"resourceVersion,omitempty"`
 	ResourceContainers ResourceContainers `json:"resourceContainers,omitempty"`
-	CreatedDate        time.Time          `json:"createdDate,omitempty"`
+	CreatedDate        Time               `json:"createdDate,omitempty"`
 	Resource           interface{}
 	PayloadType        PayloadType
 }

--- a/azuredevops/git.go
+++ b/azuredevops/git.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 )
 
 // VersionControlChangeType enum declaration
@@ -170,13 +169,13 @@ type GitPullRequest struct {
 	ArtifactID            *string                          `json:"artifactId,omitempty"`
 	AutoCompleteSetBy     *IdentityRef                     `json:"autoCompleteSetBy,omitempty"`
 	ClosedBy              *IdentityRef                     `json:"closedBy,omitempty"`
-	ClosedDate            *time.Time                       `json:"closedDate,omitempty"`
+	ClosedDate            *Time                            `json:"closedDate,omitempty"`
 	CodeReviewID          *int                             `json:"codeReviewId,omitempty"`
 	Commits               []*GitCommitRef                  `json:"commits,omitempty"`
 	CompletionOptions     *GitPullRequestCompletionOptions `json:"completionOptions,omitempty"`
-	CompletionQueueTime   *time.Time                       `json:"completionQueueTime,	omitempty"`
+	CompletionQueueTime   *Time                            `json:"completionQueueTime,	omitempty"`
 	CreatedBy             *IdentityRef                     `json:"createdBy,omitempty"`
-	CreationDate          *time.Time                       `json:"creationDate,omitempty"`
+	CreationDate          *Time                            `json:"creationDate,omitempty"`
 	Description           *string                          `json:"description,omitempty"`
 	ForkSource            *GitRef                          `json:"forkSource,omitempty"`
 	IsDraft               *bool                            `json:"isDraft,omitempty"`
@@ -246,7 +245,7 @@ func (d GitPullRequestMergeStrategy) String() string {
 type GitPush struct {
 	Links      *map[string]Link `json:"_links,omitempty"`
 	Commits    []*GitCommitRef  `json:"commits,omitempty"`
-	Date       *time.Time       `json:"date,omitempty"`
+	Date       *Time            `json:"date,omitempty"`
 	PushID     *int             `json:"pushId,omitempty"`
 	PushedBy   *IdentityRef     `json:"pushedBy,omitempty"`
 	RefUpdates []*GitRefUpdate  `json:"refUpdates,omitempty"`
@@ -321,12 +320,12 @@ type GitStatus struct {
 	Links        *map[string]Link  `json:"_links,omitempty"`
 	Context      *GitStatusContext `json:"context,omitempty"`
 	CreatedBy    *IdentityRef      `json:"createdBy,omitempty"`
-	CreationDate *time.Time        `json:"creationDate,omitempty"`
+	CreationDate *Time             `json:"creationDate,omitempty"`
 	Description  *string           `json:"description,omitempty"`
 	ID           *int              `json:"id,omitempty"`
 	State        *string           `json:"state,omitempty"`
 	TargetURL    *string           `json:"targetUrl,omitempty"`
-	UpdatedDate  *time.Time        `json:"updatedDate,omitempty"`
+	UpdatedDate  *Time             `json:"updatedDate,omitempty"`
 }
 
 // GitPullRequestStatus This class contains the metadata of a service/extension
@@ -334,8 +333,8 @@ type GitStatus struct {
 // an iteration.
 type GitPullRequestStatus struct {
 	GitStatus
-	IterationID int        `json:"iterationId,omitempty"`
-	Properties  *time.Time `json:"properties,omitempty"`
+	IterationID int   `json:"iterationId,omitempty"`
+	Properties  *Time `json:"properties,omitempty"`
 }
 
 // GitRefListOptions describes what the request to the API should look like
@@ -359,9 +358,9 @@ type GitTemplate struct {
 
 // GitUserDate User info and date for Git operations.
 type GitUserDate struct {
-	Name  *string    `json:"name,omitempty"`
-	Email *string    `json:"email,omitempty"`
-	Date  *time.Time `json:"date,omitempty"`
+	Name  *string `json:"name,omitempty"`
+	Email *string `json:"email,omitempty"`
+	Date  *Time   `json:"date,omitempty"`
 }
 
 // UpdateRefs returns a list of the references for a git repo

--- a/azuredevops/pull_requests.go
+++ b/azuredevops/pull_requests.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 )
 
 // Vote identifiers
@@ -300,10 +299,10 @@ type Comment struct {
 	Content                *string          `json:"content,omitempty"`
 	ID                     *int             `json:"id,omitempty"`
 	IsDeleted              *bool            `json:"isDeleted,omitempty"`
-	LastContentUpdatedDate *time.Time       `json:"lastContentUpdatedDate,omitempty"`
-	LastUpdatedDate        *time.Time       `json:"lastUpdatedDate,omitempty"`
+	LastContentUpdatedDate *Time            `json:"lastContentUpdatedDate,omitempty"`
+	LastUpdatedDate        *Time            `json:"lastUpdatedDate,omitempty"`
 	ParentCommentID        *int             `json:"parentCommentId,omitempty"`
-	PublishedDate          *time.Time       `json:"publishedDate,omitempty"`
+	PublishedDate          *Time            `json:"publishedDate,omitempty"`
 	UsersLiked             []*IdentityRef   `json:"usersLiked,omitempty"`
 }
 
@@ -322,9 +321,9 @@ type GitPullRequestCommentThread struct {
 	ID                       *int                                `json:"id,omitempty"`
 	Identities               []*IdentityRef                      `json:"identities,omitempty"`
 	IsDeleted                *bool                               `json:"isDeleted,omitempty"`
-	LastUpdatedDate          *time.Time                          `json:"lastUpdatedDate,omitempty"`
+	LastUpdatedDate          *Time                               `json:"lastUpdatedDate,omitempty"`
 	Properties               []*int                              `json:"properties,omitempty"`
-	PublishedDate            *time.Time                          `json:"publishedDate,omitempty"`
+	PublishedDate            *Time                               `json:"publishedDate,omitempty"`
 	Status                   *string                             `json:"status,omitempty"`
 	PullRequestThreadContext *GitPullRequestCommentThreadContext `json:"pullRequestThreadContext,omitempty"`
 }

--- a/azuredevops/teams.go
+++ b/azuredevops/teams.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 )
 
 // TeamsService handles communication with the teams methods on the API
@@ -15,14 +14,14 @@ type TeamsService struct {
 
 // Project Describes a project
 type Project struct {
-	ID             *string    `json:"id,omitempty"`
-	Name           *string    `json:"name,omitempty"`
-	Description    *string    `json:"description,omitempty"`
-	URL            *string    `json:"url,omitempty"`
-	State          *string    `json:"state,omitempty"`
-	Revision       *int       `json:"revision,omitempty"`
-	Visibility     *string    `json:"visibility,omitempty"`
-	LastUpdateTime *time.Time `json:"lastUpdateTime,omitempty"`
+	ID             *string `json:"id,omitempty"`
+	Name           *string `json:"name,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	URL            *string `json:"url,omitempty"`
+	State          *string `json:"state,omitempty"`
+	Revision       *int    `json:"revision,omitempty"`
+	Visibility     *string `json:"visibility,omitempty"`
+	LastUpdateTime *Time   `json:"lastUpdateTime,omitempty"`
 }
 
 // Team describes what a team looks like
@@ -55,16 +54,16 @@ type TeamProjectCollectionReference struct {
 
 // TeamProjectReference Represents a shallow reference to a TeamProject.
 type TeamProjectReference struct {
-	Abbreviation        *string    `json:"abbreviation,omitempty"`
-	DefaultTeamImageURL *string    `json:"defaultTeamImageUrl,omitempty"`
-	Description         *string    `json:"description,omitempty"`
-	ID                  *string    `json:"id,omitempty"`
-	Name                *string    `json:"name,omitempty"`
-	Revision            *int       `json:"revision,omitempty"`
-	State               *string    `json:"state,omitempty"`
-	URL                 *string    `json:"url,omitempty"`
-	Visibility          *string    `json:"visibility,omitempty"`
-	LastUpdateTime      *time.Time `json:"lastUpdateTime,omitempty"`
+	Abbreviation        *string `json:"abbreviation,omitempty"`
+	DefaultTeamImageURL *string `json:"defaultTeamImageUrl,omitempty"`
+	Description         *string `json:"description,omitempty"`
+	ID                  *string `json:"id,omitempty"`
+	Name                *string `json:"name,omitempty"`
+	Revision            *int    `json:"revision,omitempty"`
+	State               *string `json:"state,omitempty"`
+	URL                 *string `json:"url,omitempty"`
+	Visibility          *string `json:"visibility,omitempty"`
+	LastUpdateTime      *Time   `json:"lastUpdateTime,omitempty"`
 }
 
 // List returns list of the teams

--- a/azuredevops/tests.go
+++ b/azuredevops/tests.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 )
 
 // TestsService handles communication with the Tests methods on the API
@@ -77,11 +76,11 @@ type TestResult struct {
 		Name string `json:"name"`
 		URL  string `json:"url"`
 	} `json:"project"`
-	StartedDate   time.Time `json:"startedDate"`
-	CompletedDate time.Time `json:"completedDate"`
-	DurationInMs  float64   `json:"durationInMs"`
-	Outcome       string    `json:"outcome"`
-	Revision      int       `json:"revision"`
+	StartedDate   Time    `json:"startedDate"`
+	CompletedDate Time    `json:"completedDate"`
+	DurationInMs  float64 `json:"durationInMs"`
+	Outcome       string  `json:"outcome"`
+	Revision      int     `json:"revision"`
 	RunBy         struct {
 		ID          string `json:"id"`
 		DisplayName string `json:"displayName"`
@@ -99,7 +98,7 @@ type TestResult struct {
 		Name string `json:"name"`
 		URL  string `json:"url"`
 	} `json:"testRun"`
-	LastUpdatedDate time.Time `json:"lastUpdatedDate"`
+	LastUpdatedDate Time `json:"lastUpdatedDate"`
 	LastUpdatedBy   struct {
 		ID          string `json:"id"`
 		DisplayName string `json:"displayName"`
@@ -114,13 +113,13 @@ type TestResult struct {
 		Name string `json:"name"`
 		URL  string `json:"url"`
 	} `json:"build"`
-	CreatedDate          time.Time `json:"createdDate"`
-	URL                  string    `json:"url"`
-	FailureType          string    `json:"failureType"`
-	AutomatedTestStorage string    `json:"automatedTestStorage"`
-	AutomatedTestType    string    `json:"automatedTestType"`
-	AutomatedTestTypeID  string    `json:"automatedTestTypeId"`
-	AutomatedTestID      string    `json:"automatedTestId"`
+	CreatedDate          Time   `json:"createdDate"`
+	URL                  string `json:"url"`
+	FailureType          string `json:"failureType"`
+	AutomatedTestStorage string `json:"automatedTestStorage"`
+	AutomatedTestType    string `json:"automatedTestType"`
+	AutomatedTestTypeID  string `json:"automatedTestTypeId"`
+	AutomatedTestID      string `json:"automatedTestId"`
 	Area                 struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`

--- a/azuredevops/users.go
+++ b/azuredevops/users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 )
 
 // UsersService handles communication with the Graph.Users methods on the API
@@ -108,8 +107,8 @@ type GraphSubject struct {
 // GraphUser is the parent struct describing a Microsoft Graph user for Azure Devops
 type GraphUser struct {
 	GraphMember
-	IsDeletedInOrigin  *bool      `json:"isDeletedOrigin,omitempty"`
-	MetadataUpdateDate *time.Time `json:"metadataUpdateDate,omitempty"`
+	IsDeletedInOrigin  *bool `json:"isDeletedOrigin,omitempty"`
+	MetadataUpdateDate *Time `json:"metadataUpdateDate,omitempty"`
 	/**
 	* The meta type of the user in the origin, such as "member", "guest",
 	* etc. See UserMetaType for the set of possible values.

--- a/azuredevops/work_items.go
+++ b/azuredevops/work_items.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // WorkItemsService handles communication with the work items methods on the API
@@ -26,10 +25,10 @@ type IterationWorkItems struct {
 // WorkItemComment Describes a response to CreateComment
 type WorkItemComment struct {
 	CreatedBy    *IdentityRef `json:"createdBy,omitempty"`
-	CreatedDate  *time.Time   `json:"createdDate,omitempty"`
+	CreatedDate  *Time        `json:"createdDate,omitempty"`
 	ID           *int         `json:"id,omitempty"`
 	ModifiedBy   *IdentityRef `json:"modifiedBy,omitempty"`
-	ModifiedDate *time.Time   `json:"modifiedDate,omitempty"`
+	ModifiedDate *Time        `json:"modifiedDate,omitempty"`
 	Text         *string      `json:"text,omitempty"`
 	URL          *string      `json:"url,omitempty"`
 	Version      *int         `json:"version,omitempty"`
@@ -121,7 +120,7 @@ type WorkItemUpdate struct {
 	Relations   *WorkItemRelationUpdates        `json:"relations,omitempty"`
 	Rev         *int                            `json:"rev,omitempty"`
 	RevisedBy   *IdentityRef                    `json:"revisedBy,omitempty"`
-	RevisedDate *time.Time                      `json:"revisedDate,omitempty"`
+	RevisedDate *Time                           `json:"revisedDate,omitempty"`
 	WorkItemID  *int                            `json:"workItemId,omitempty"`
 	URL         *string                         `json:"url,omitempty"`
 }


### PR DESCRIPTION
Edit: Reference source

Adds a custom Time type and uses that in place of time.Time with a custom Unmarshaler.  Copied the code snippet from the PR https://github.com/microsoft/azure-devops-go-api/pull/18.