### PR TITLE
GetUserId by organization name and user name

### DIFF
--- a/azuredevops/azuredevops.go
+++ b/azuredevops/azuredevops.go
@@ -21,6 +21,8 @@ const (
 	DefaultBaseURL string = "https://dev.azure.com/"
 	// DefaultVsspsBaseURL is the default URI base for some Azure Devops REST API endpoints
 	DefaultVsspsBaseURL string = "https://vssps.dev.azure.com/"
+	// DefaultVsspsBaseURL is the default URI base for some Azure Devops REST API endpoints
+	DefaultVsaexBaseURL string = "https://vsaex.dev.azure.com/"
 	// userAgent our HTTP client's user-agent
 	userAgent string = "go-azuredevops"
 )
@@ -33,6 +35,8 @@ type Client struct {
 	BaseURL url.URL
 
 	VsspsBaseURL url.URL
+
+	VsaexBaseURL url.URL
 
 	UserAgent string
 
@@ -52,6 +56,7 @@ type Client struct {
 	Teams             *TeamsService
 	Tests             *TestsService
 	Users             *UsersService
+	UserEntitlements  *UserEntitlementsService
 	WorkItems         *WorkItemsService
 }
 
@@ -65,12 +70,15 @@ func NewClient(httpClient *http.Client) (*Client, error) {
 	}
 
 	c := &Client{}
+
 	baseURL, _ := url.Parse(DefaultBaseURL)
 	vsspsBaseURL, _ := url.Parse(DefaultVsspsBaseURL)
+	vsaexBaseURL, _ := url.Parse(DefaultVsaexBaseURL)
 
 	c.client = httpClient
 	c.BaseURL = *baseURL
 	c.VsspsBaseURL = *vsspsBaseURL
+	c.VsaexBaseURL = *vsaexBaseURL
 	c.UserAgent = userAgent
 
 	c.Boards = &BoardsService{client: c}
@@ -85,6 +93,7 @@ func NewClient(httpClient *http.Client) (*Client, error) {
 	c.Teams = &TeamsService{client: c}
 	c.Tests = &TestsService{client: c}
 	c.Users = &UsersService{client: c}
+	c.UserEntitlements = &UserEntitlementsService{client: c}
 	c.WorkItems = &WorkItemsService{client: c}
 
 	return c, nil
@@ -96,11 +105,21 @@ func NewClient(httpClient *http.Client) (*Client, error) {
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
 func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+	req, err := c.NewRequestEx(method, c.BaseURL, urlStr, body)
+	if err == nil {
+		return req, nil
+	} else {
+		return nil, err
+	}
+}
+
+// NewRequestEx is an extension of NewRequest to inject custom base URL
+func (c *Client) NewRequestEx(method string, baseURL url.URL, urlStr string, body interface{}) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
 		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL.String())
 	}
 
-	u, err := c.BaseURL.Parse(urlStr)
+	u, err := baseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}

--- a/azuredevops/azuredevops.go
+++ b/azuredevops/azuredevops.go
@@ -21,7 +21,7 @@ const (
 	DefaultBaseURL string = "https://dev.azure.com/"
 	// DefaultVsspsBaseURL is the default URI base for some Azure Devops REST API endpoints
 	DefaultVsspsBaseURL string = "https://vssps.dev.azure.com/"
-	// DefaultVsspsBaseURL is the default URI base for some Azure Devops REST API endpoints
+	// DefaultVsaexBaseURL is the default URI base for some Azure Devops REST API endpoints
 	DefaultVsaexBaseURL string = "https://vsaex.dev.azure.com/"
 	// userAgent our HTTP client's user-agent
 	userAgent string = "go-azuredevops"
@@ -105,21 +105,11 @@ func NewClient(httpClient *http.Client) (*Client, error) {
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
 func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
-	req, err := c.NewRequestEx(method, c.BaseURL, urlStr, body)
-	if err == nil {
-		return req, nil
-	} else {
-		return nil, err
-	}
-}
-
-// NewRequestEx is an extension of NewRequest to inject custom base URL
-func (c *Client) NewRequestEx(method string, baseURL url.URL, urlStr string, body interface{}) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
 		return nil, fmt.Errorf("BaseURL must have a trailing slash, but %q does not", c.BaseURL.String())
 	}
 
-	u, err := baseURL.Parse(urlStr)
+	u, err := c.BaseURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}

--- a/azuredevops/userentitlements.go
+++ b/azuredevops/userentitlements.go
@@ -1,0 +1,106 @@
+package azuredevops
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// UserEntitlementsService handles communication with the user entitlements methods on the API
+// utilising https://docs.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user%20entitlements?view=azure-devops-rest-6.0
+type UserEntitlementsService struct {
+	client *Client
+}
+
+// UserEntitlements is a wrapper class around the main response for the Get of UserEntitlement
+type UserEntitlements struct {
+	Members           []Item      `json:"members"`
+	ContinuationToken interface{} `json:"continuationToken"`
+	TotalCount        int64       `json:"totalCount"`
+	Items             []Item      `json:"items"`
+}
+
+// Item is a wrapper class used by UserEntitlements
+type Item struct {
+	ID                  string        `json:"id"`
+	User                User          `json:"user"`
+	AccessLevel         AccessLevel   `json:"accessLevel"`
+	LastAccessedDate    string        `json:"lastAccessedDate"`
+	DateCreated         string        `json:"dateCreated"`
+	ProjectEntitlements []interface{} `json:"projectEntitlements"`
+	Extensions          []interface{} `json:"extensions"`
+	GroupAssignments    []interface{} `json:"groupAssignments"`
+}
+
+// AccessLevel is a wrapper class used by Item
+type AccessLevel struct {
+	LicensingSource    string `json:"licensingSource"`
+	AccountLicenseType string `json:"accountLicenseType"`
+	MSDNLicenseType    string `json:"msdnLicenseType"`
+	LicenseDisplayName string `json:"licenseDisplayName"`
+	Status             string `json:"status"`
+	StatusMessage      string `json:"statusMessage"`
+	AssignmentSource   string `json:"assignmentSource"`
+}
+
+// User is a wrapper class used by Item
+type User struct {
+	SubjectKind   string  `json:"subjectKind"`
+	MetaType      *string `json:"metaType,omitempty"`
+	Domain        string  `json:"domain"`
+	PrincipalName string  `json:"principalName"`
+	MailAddress   string  `json:"mailAddress"`
+	Origin        string  `json:"origin"`
+	OriginID      string  `json:"originId"`
+	DisplayName   string  `json:"displayName"`
+	Links         Links   `json:"_links"`
+	URL           string  `json:"url"`
+	Descriptor    string  `json:"descriptor"`
+}
+
+// Links is a wrapper class used by User
+type Links struct {
+	Self            Avatar `json:"self"`
+	Memberships     Avatar `json:"memberships"`
+	MembershipState Avatar `json:"membershipState"`
+	StorageKey      Avatar `json:"storageKey"`
+	Avatar          Avatar `json:"avatar"`
+}
+
+// Avatar is a wrapper class used by Links
+type Avatar struct {
+	Href string `json:"href"`
+}
+
+// Get returns a single user entitlement filtering by the user name in the organization
+// https://docs.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user%20entitlements/search%20user%20entitlements?view=azure-devops-rest-6.0
+func (s *UserEntitlementsService) Get(ctx context.Context, userName string, orgName string) (*UserEntitlements, *http.Response, error) {
+	URL := fmt.Sprintf("/%s/_apis/userentitlements?$filter=name+eq+'%s'&$api-version=6.0-preview.3", orgName, userName)
+	req, err := s.client.NewRequestEx("GET", s.client.VsaexBaseURL, URL, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	r := new(UserEntitlements)
+	resp, err := s.client.Execute(ctx, req, r)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return r, resp, err
+}
+
+// GetUserID returns the user id by the user name and the organizatino name
+func (s *UserEntitlementsService) GetUserID(ctx context.Context, userName string, orgName string) (*string, error) {
+	userEntitlements, _, err := s.Get(context.Background(), userName, orgName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(userEntitlements.Items) > 0{
+		return &userEntitlements.Items[0].ID, nil
+	} else {
+		var nilValue *string = nil
+		return nilValue, nil
+	}
+}

--- a/azuredevops/userentitlements.go
+++ b/azuredevops/userentitlements.go
@@ -15,7 +15,7 @@ type UserEntitlementsService struct {
 // UserEntitlements is a wrapper class around the main response for the Get of UserEntitlement
 type UserEntitlements struct {
 	Members           []Item      `json:"members,omitempty"`
-	ContinuationToken interface{} `json:"continuationToken,omitempty"`
+	ContinuationToken interface{} `json:"continuationToken"`
 	TotalCount        int64       `json:"totalCount,omitempty"`
 	Items             []Item      `json:"items,omitempty"`
 }
@@ -104,8 +104,7 @@ func (s *UserEntitlementsService) GetUserID(ctx context.Context, userName string
 
 	if len(userEntitlements.Items) > 0 {
 		return &userEntitlements.Items[0].ID, nil
-	} else {
-		var nilValue *string = nil
-		return nilValue, nil
 	}
+	var nilValue *string = nil
+	return nilValue, nil
 }

--- a/azuredevops/userentitlements.go
+++ b/azuredevops/userentitlements.go
@@ -14,48 +14,48 @@ type UserEntitlementsService struct {
 
 // UserEntitlements is a wrapper class around the main response for the Get of UserEntitlement
 type UserEntitlements struct {
-	Members           []Item      `json:"members"`
-	ContinuationToken interface{} `json:"continuationToken"`
-	TotalCount        int64       `json:"totalCount"`
-	Items             []Item      `json:"items"`
+	Members           []Item      `json:"members,omitempty"`
+	ContinuationToken interface{} `json:"continuationToken,omitempty"`
+	TotalCount        int64       `json:"totalCount,omitempty"`
+	Items             []Item      `json:"items,omitempty"`
 }
 
 // Item is a wrapper class used by UserEntitlements
 type Item struct {
-	ID                  string        `json:"id"`
+	ID                  string        `json:"id,omitempty"`
 	User                User          `json:"user"`
 	AccessLevel         AccessLevel   `json:"accessLevel"`
-	LastAccessedDate    string        `json:"lastAccessedDate"`
-	DateCreated         string        `json:"dateCreated"`
-	ProjectEntitlements []interface{} `json:"projectEntitlements"`
-	Extensions          []interface{} `json:"extensions"`
-	GroupAssignments    []interface{} `json:"groupAssignments"`
+	LastAccessedDate    string        `json:"lastAccessedDate,omitempty"`
+	DateCreated         string        `json:"dateCreated,omitempty"`
+	ProjectEntitlements []interface{} `json:"projectEntitlements,omitempty"`
+	Extensions          []interface{} `json:"extensions,omitempty"`
+	GroupAssignments    []interface{} `json:"groupAssignments,omitempty"`
 }
 
 // AccessLevel is a wrapper class used by Item
 type AccessLevel struct {
-	LicensingSource    string `json:"licensingSource"`
-	AccountLicenseType string `json:"accountLicenseType"`
-	MSDNLicenseType    string `json:"msdnLicenseType"`
-	LicenseDisplayName string `json:"licenseDisplayName"`
-	Status             string `json:"status"`
-	StatusMessage      string `json:"statusMessage"`
-	AssignmentSource   string `json:"assignmentSource"`
+	LicensingSource    string `json:"licensingSource,omitempty"`
+	AccountLicenseType string `json:"accountLicenseType,omitempty"`
+	MSDNLicenseType    string `json:"msdnLicenseType,omitempty"`
+	LicenseDisplayName string `json:"licenseDisplayName,omitempty"`
+	Status             string `json:"status,omitempty"`
+	StatusMessage      string `json:"statusMessage,omitempty"`
+	AssignmentSource   string `json:"assignmentSource,omitempty"`
 }
 
 // User is a wrapper class used by Item
 type User struct {
-	SubjectKind   string  `json:"subjectKind"`
+	SubjectKind   string  `json:"subjectKind,omitempty"`
 	MetaType      *string `json:"metaType,omitempty"`
-	Domain        string  `json:"domain"`
-	PrincipalName string  `json:"principalName"`
-	MailAddress   string  `json:"mailAddress"`
-	Origin        string  `json:"origin"`
-	OriginID      string  `json:"originId"`
-	DisplayName   string  `json:"displayName"`
-	Links         Links   `json:"_links"`
-	URL           string  `json:"url"`
-	Descriptor    string  `json:"descriptor"`
+	Domain        string  `json:"domain,omitempty"`
+	PrincipalName string  `json:"principalName,omitempty"`
+	MailAddress   string  `json:"mailAddress,omitempty"`
+	Origin        string  `json:"origin,omitempty"`
+	OriginID      string  `json:"originId,omitempty"`
+	DisplayName   string  `json:"displayName,omitempty"`
+	Links         Links   `json:"_links,omitempty"`
+	URL           string  `json:"url,omitempty"`
+	Descriptor    string  `json:"descriptor,omitempty"`
 }
 
 // Links is a wrapper class used by User
@@ -75,8 +75,13 @@ type Avatar struct {
 // Get returns a single user entitlement filtering by the user name in the organization
 // https://docs.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user%20entitlements/search%20user%20entitlements?view=azure-devops-rest-6.0
 func (s *UserEntitlementsService) Get(ctx context.Context, userName string, orgName string) (*UserEntitlements, *http.Response, error) {
-	URL := fmt.Sprintf("/%s/_apis/userentitlements?$filter=name+eq+'%s'&$api-version=6.0-preview.3", orgName, userName)
-	req, err := s.client.NewRequestEx("GET", s.client.VsaexBaseURL, URL, nil)
+	URL := fmt.Sprintf("%s/%s/_apis/userentitlements?$filter=name+eq+'%s'&$api-version=6.0-preview.3",
+		s.client.VsaexBaseURL.String(),
+		orgName,
+		userName,
+	)
+
+	req, err := s.client.NewRequest("GET", URL, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -97,7 +102,7 @@ func (s *UserEntitlementsService) GetUserID(ctx context.Context, userName string
 		return nil, err
 	}
 
-	if len(userEntitlements.Items) > 0{
+	if len(userEntitlements.Items) > 0 {
 		return &userEntitlements.Items[0].ID, nil
 	} else {
 		var nilValue *string = nil

--- a/azuredevops/userentitlements_test.go
+++ b/azuredevops/userentitlements_test.go
@@ -85,7 +85,7 @@ func Test_UserEntitlementsGetUserId(t *testing.T) {
 		t.Fatalf("returned error: %v", err)
 	}
 
-	want := "6416203b-98bb-4910-8f8a-b12aa19a399"
+	want := "6416203b-98bb-4910-8f8a-b12aa19a399f"
 
 	if !cmp.Equal(got, &want) {
 		diff := cmp.Diff(got, &want)

--- a/azuredevops/userentitlements_test.go
+++ b/azuredevops/userentitlements_test.go
@@ -88,7 +88,7 @@ func Test_UserEntitlementsGetUserId(t *testing.T) {
 	want := "6416203b-98bb-4910-8f8a-b12aa19a399f"
 
 	if !cmp.Equal(got, &want) {
-		diff := cmp.Diff(got, want)
+		diff := cmp.Diff(got, &want)
 		fmt.Printf(diff)
 		t.Errorf("UserEntitlements.GetUserId returned %+v, want %+v", got, want)
 	}

--- a/azuredevops/userentitlements_test.go
+++ b/azuredevops/userentitlements_test.go
@@ -85,11 +85,11 @@ func Test_UserEntitlementsGetUserId(t *testing.T) {
 		t.Fatalf("returned error: %v", err)
 	}
 
-	want := "6416203b-98bb-4910-8f8a-b12aa19a399f"
+	want := "6416203b-98bb-4910-8f8a-b12aa19a399"
 
 	if !cmp.Equal(got, &want) {
 		diff := cmp.Diff(got, &want)
 		fmt.Printf(diff)
-		t.Errorf("UserEntitlements.GetUserId returned %+v, want %+v", got, want)
+		t.Errorf("UserEntitlements.GetUserId returned %+v, want %+v", *got, want)
 	}
 }

--- a/azuredevops/userentitlements_test.go
+++ b/azuredevops/userentitlements_test.go
@@ -1,0 +1,95 @@
+package azuredevops_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mcdafydd/go-azuredevops/azuredevops"
+)
+
+func Test_UserEntitlementsGet(t *testing.T) {
+	c, mux, _, teardown := setup()
+	defer teardown()
+	u, _ := url.Parse("")
+	c.VsaexBaseURL = *u
+	mux.HandleFunc("/orgName/_apis/userentitlements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+				"members": [
+					{
+						"id": "6416203b-98bb-4910-8f8a-b12aa19a399f"
+					}
+				],
+				"continuationToken": null,
+				"totalCount": 0,
+				"items": [
+					{
+						"id": "6416203b-98bb-4910-8f8a-b12aa19a399f"
+					}
+				]
+		}`)
+	})
+
+	got, _, err := c.UserEntitlements.Get(context.Background(), "userName", "orgName")
+	if err != nil {
+		t.Fatalf("returned error: %v", err)
+	}
+
+	want := &azuredevops.UserEntitlements{}
+	item := azuredevops.Item{
+		ID: "6416203b-98bb-4910-8f8a-b12aa19a399f",
+	}
+	items := []azuredevops.Item{item}
+	want.Members = items
+	want.Items = items
+	want.TotalCount = 0
+
+	if !cmp.Equal(got, want) {
+		diff := cmp.Diff(got, want)
+		fmt.Printf(diff)
+		t.Errorf("UserEntitlements.Get returned %+v, want %+v", got, want)
+	}
+}
+
+func Test_UserEntitlementsGetUserId(t *testing.T) {
+	c, mux, _, teardown := setup()
+	defer teardown()
+	u, _ := url.Parse("")
+	c.VsaexBaseURL = *u
+	mux.HandleFunc("/orgName/_apis/userentitlements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+				"members": [
+					{
+						"id": "6416203b-98bb-4910-8f8a-b12aa19a399f"
+					}
+				],
+				"continuationToken": null,
+				"totalCount": 0,
+				"items": [
+					{
+						"id": "6416203b-98bb-4910-8f8a-b12aa19a399f"
+					}
+				]
+		}`)
+	})
+
+	got, err := c.UserEntitlements.GetUserID(context.Background(), "userName", "orgName")
+	if err != nil {
+		t.Fatalf("returned error: %v", err)
+	}
+
+	want := "6416203b-98bb-4910-8f8a-b12aa19a399f"
+
+	if !cmp.Equal(got, &want) {
+		diff := cmp.Diff(got, want)
+		fmt.Printf(diff)
+		t.Errorf("UserEntitlements.GetUserId returned %+v, want %+v", got, want)
+	}
+}

--- a/examples/getuserid/main.go
+++ b/examples/getuserid/main.go
@@ -9,13 +9,14 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"bufio"
 	"os"
 	"strings"
 	"syscall"
-	"go-azuredevops/azuredevops"
+
+	"github.com/mcdafydd/go-azuredevops/azuredevops"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -29,7 +30,7 @@ func main() {
 	bytePassword, _ := terminal.ReadPassword(int(syscall.Stdin))
 	token := string(bytePassword)
 	fmt.Print("\n")
-	
+
 	r = bufio.NewReader(os.Stdin)
 	fmt.Print("Azure Devops User name: ")
 	userName, _ := r.ReadString('\n')

--- a/examples/getuserid/main.go
+++ b/examples/getuserid/main.go
@@ -1,0 +1,55 @@
+// Copyright 2020 go-azuredevops AUTHORS. All rights reserved.
+//
+// This example uses the go-azuredevops library to get the Azure DevOps user Id
+// by the specified user name and organization name
+// 0. Prompts the user for required inputs: organization name, user name, personal access token
+// 1. Creates a NewClient() using basic auth and personal access token
+// 2. Gets the user Id
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"bufio"
+	"os"
+	"strings"
+	"syscall"
+	"go-azuredevops/azuredevops"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func main() {
+	r := bufio.NewReader(os.Stdin)
+	fmt.Print("Azure Devops Organization name: ")
+	orgName, _ := r.ReadString('\n')
+	orgName = strings.TrimSuffix(orgName, "\r\n")
+
+	fmt.Print("Azure Devops Personal Access Token: ")
+	bytePassword, _ := terminal.ReadPassword(int(syscall.Stdin))
+	token := string(bytePassword)
+	fmt.Print("\n")
+	
+	r = bufio.NewReader(os.Stdin)
+	fmt.Print("Azure Devops User name: ")
+	userName, _ := r.ReadString('\n')
+	userName = strings.TrimSuffix(userName, "\r\n")
+
+	tp := azuredevops.BasicAuthTransport{
+		Username: "",
+		Password: token,
+	}
+
+	client, _ := azuredevops.NewClient(tp.Client())
+
+	result, err := client.UserEntitlements.GetUserID(context.Background(), userName, orgName)
+	if err != nil {
+		fmt.Printf("Error trying to list user entitlements: %+v\n", err)
+	}
+
+	if result == nil {
+		fmt.Print("User not found")
+	} else {
+		fmt.Printf("Azure DevOps User ID: %v", *result)
+	}
+}


### PR DESCRIPTION
This is a feature upgrade utilizing the user entitlements DevOps API 
The GeUserID function of the UserEntitlementsService returns the Azure DevOps user id by the organization name and user name, this functionality is required to be able to fix an Azure related bug of runatlantis/atlantis
New files:
 userentitlements.go: contains the new functionality
 examples/getuserid/main.go: an example of using the new functionality
Modified files:
 azuredevops.go: UserEntitlementService is added
 


