### PR TITLE
Fix ChangeCounts json.Unmarshal Error

### DIFF
--- a/azuredevops/git.go
+++ b/azuredevops/git.go
@@ -30,7 +30,7 @@ const (
 )
 
 func (d VersionControlChangeType) String() string {
-	return [...]string{"none", "add", "edit", "encoding", "rename", "delete", "undelete", "branch", "merge", "lock", "rollback", "sourceRename", "targetRename", "property", "all"}[d]
+	return [...]string{"None", "Add", "Edit", "Encoding", "Rename", "Delete", "Undelete", "Branch", "Merge", "Lock", "Rollback", "SourceRename", "TargetRename", "Property", "All"}[d]
 }
 
 // GitObjectType enum declaration

--- a/azuredevops/git_test.go
+++ b/azuredevops/git_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -225,7 +226,7 @@ func TestGitService_GetChanges(t *testing.T) {
 
 	changes := &azuredevops.GitChange{
 		ChangeID:   Int(1),
-		ChangeType: String(azuredevops.Add.String()),
+		ChangeType: String(strings.ToLower(azuredevops.Add.String())),
 	}
 	changesList := []*azuredevops.GitChange{changes}
 	want := &azuredevops.GitCommitChanges{
@@ -240,7 +241,7 @@ func TestGitService_GetChanges(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{
 			"changeCounts": {
-				"add": 1
+				"Add": 1
 			},
 			"changes": [{
 				"changeId": 1,


### PR DESCRIPTION
The changecounts response from the API has a TitleCase format for the keys, not lowercase. 

Added a test to reflect the use of changecounts
Modified the test for looking at the changetype filed to lowercase

It's pretty  crazy that AzDo is mixing string case like this...

Example response from azdo API:

```
{
  "changeCounts": {
    "Edit": 1,
    "Add": 1
  },
  "changes": [
    {
      "item": {
        "objectId": "XXX",
        "originalObjectId": "XXX",
        "gitObjectType": "blob",
        "commitId": "XXXX",
        "path": "/file.yaml",
        "url": "https://XXX"
      },
      "changeType": "edit"
    },
    {
      "item": {
        "objectId": "XXX",
        "originalObjectId": "XXX",
        "gitObjectType": "blob",
        "commitId": "XXXX",
        "path": "/file2.yaml",
        "url": "https://XXX"
      },
      "changeType": "add"
    }
  ]
}

```

Notice how `changeCounts` has `Edit` (titlecase) but `changeType` has `edit` (lowercase)